### PR TITLE
Run migrations before deploying new image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ deploy:
 
 .PHONY: migrate
 migrate:
-	$(DOCKER_COMPOSE) exec $(service) python manage.py migrate
+	docker run --rm -it --net=$(DOCKER_NETWORK) \
+		--env-file=conf/portal/.chameleon_env $(PORTAL_TAG) \
+		python manage.py migrate
 
 .PHONY: collectstatic
 collectstatic:

--- a/conf/camino/dev.env
+++ b/conf/camino/dev.env
@@ -1,3 +1,4 @@
 PORTAL_TAG=docker.chameleoncloud.org/portal:latest
 REFERENCEAPI_TAG=docker.chameleoncloud.org/referenceapi:fa7c701
 COMPOSE_FILE=docker-compose.dev.yml
+DOCKER_NETWORK=portal

--- a/conf/camino/prod.env
+++ b/conf/camino/prod.env
@@ -1,3 +1,4 @@
 PORTAL_TAG=docker.chameleoncloud.org/portal:c91c968
 REFERENCEAPI_TAG=docker.chameleoncloud.org/referenceapi:fa7c701
 COMPOSE_FILE=docker-compose.yml
+DOCKER_NETWORK=chameleon_default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,4 +60,4 @@ services:
 networks:
   app:
     external: true
-    name: chameleon_default
+    name: ${DOCKER_NETWORK}


### PR DESCRIPTION
In most cases, deploying a new image before running migrations will
break the app, because it's referencing models that haven't been updated
at the DB level.

This changes the migrate task to execute migrations against the running
compose environment without pulling and restarting the portal service.
The workflow is now:

```
make migrate
make deploy service=portal
```