### PR TITLE
Update configuration for new hosts

### DIFF
--- a/conf/camino/dev.env
+++ b/conf/camino/dev.env
@@ -1,3 +1,4 @@
 PORTAL_TAG=docker.chameleoncloud.org/portal:latest
 REFERENCEAPI_TAG=docker.chameleoncloud.org/referenceapi:latest
+DB_TAG=10
 COMPOSE_FILE=docker-compose.dev.yml

--- a/conf/camino/prod.env
+++ b/conf/camino/prod.env
@@ -1,3 +1,4 @@
 PORTAL_TAG=docker.chameleoncloud.org/portal:latest
 REFERENCEAPI_TAG=docker.chameleoncloud.org/referenceapi:latest
 COMPOSE_FILE=docker-compose.yml
+DB_TAG=10

--- a/conf/nginx/conf.d/referenceapi.server.conf
+++ b/conf/nginx/conf.d/referenceapi.server.conf
@@ -1,7 +1,7 @@
 server {
   listen      443 ssl;
 
-  server_name    api.chameleoncloud.org api.tacc.chameleoncloud.org;
+  server_name    api.dev.chameleoncloud.org;
   charset     utf-8;
 
   access_log /dev/stdout;

--- a/conf/nginx/conf.d/referenceapi.server.conf
+++ b/conf/nginx/conf.d/referenceapi.server.conf
@@ -7,8 +7,8 @@ server {
   access_log /dev/stdout;
   error_log  /dev/stderr info;
 
-  ssl_certificate     /etc/ssl/certs/api.portal.cer;
-  ssl_certificate_key /etc/ssl/api.chameleoncloud.org.key;
+  ssl_certificate     /etc/ssl/certs/portal.cer;
+  ssl_certificate_key /etc/ssl/private/portal.key;
   ssl_dhparam           /etc/ssl/dhparam.pem;
   ssl_protocols         TLSv1.2;
   ssl_ciphers           'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';

--- a/conf/nginx/conf.d/referenceapi.server.conf
+++ b/conf/nginx/conf.d/referenceapi.server.conf
@@ -1,7 +1,7 @@
 server {
   listen      443 ssl;
 
-  server_name    api.dev.chameleoncloud.org;
+  server_name    api.$hostname;
   charset     utf-8;
 
   access_log /dev/stdout;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,8 @@ services:
     restart: always
     logging:
       driver: journald
+    ports:
+      - "3306:3006"
     networks: 
       - app
   nginx:
@@ -37,7 +39,6 @@ services:
       # not work for dev. For now, just re-use the existing certs so it least nginx starts up.
       - /etc/letsencrypt/live/dev.chameleoncloud.org/fullchain.pem:/etc/ssl/certs/api.portal.cer
       - /etc/letsencrypt/live/dev.chameleoncloud.org/privkey.pem:/etc/ssl/api.chameleoncloud.org.key
-      - /etc/ssl/dhparam.pem:/etc/ssl/dhparam.pem
       - /var/www/chameleon/static:/static
       - /var/www/chameleon/media:/media
       - /var/www/certbot:/var/www/certbot

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -55,12 +55,6 @@ services:
     restart: always
     networks:
       - app
-  redis:
-    image: "redis:alpine"
-    restart: always
-    container_name: redis
-    networks:
-      - app
   celery:
     image: ${PORTAL_TAG}
     container_name: celery

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
     logging:
       driver: journald
     ports:
-      - "3306:3006"
+      - "3306:3306"
     networks: 
       - app
   nginx:
@@ -34,9 +34,7 @@ services:
     volumes:
       - /etc/letsencrypt/live/dev.chameleoncloud.org/fullchain.pem:/etc/ssl/certs/portal.cer
       - /etc/letsencrypt/live/dev.chameleoncloud.org/privkey.pem:/etc/ssl/private/portal.key
-      # TODO(jason): we don't yet have DNS records or certs for api.dev.chameleoncloud.org,
-      # and the nginx config also assumes a hostname api.chameleoncloud.org, which will
-      # not work for dev. For now, just re-use the existing certs so it least nginx starts up.
+      - /etc/ssl/dhparam.pem:/etc/ssl/dhparam.pem
       - /etc/letsencrypt/live/dev.chameleoncloud.org/fullchain.pem:/etc/ssl/certs/api.portal.cer
       - /etc/letsencrypt/live/dev.chameleoncloud.org/privkey.pem:/etc/ssl/api.chameleoncloud.org.key
       - /var/www/chameleon/static:/static
@@ -76,8 +74,6 @@ services:
       - ./conf/portal/.chameleon_env
     logging:
       driver: journald
-    depends_on:
-      - redis
     networks:
       - app
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,6 +42,7 @@ services:
       - /var/www/certbot:/var/www/certbot
       - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./conf/nginx/conf.d:/etc/nginx/conf.d
+    hostname: dev.chameleoncloud.org
     ports:
       - 80:80
       - 443:443

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,6 +15,18 @@ services:
       driver: journald
     networks:
       - app
+  mariadb:
+    image: mariadb:${DB_TAG}
+    volumes: 
+      - /var/lib/mysql:/var/lib/mysql
+    env_file: 
+      - ./conf/portal/.chameleon_env
+    container_name: mariadb
+    restart: always
+    logging:
+      driver: journald
+    networks: 
+      - app
   nginx:
     image: nginx
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -66,6 +66,12 @@ services:
     restart: always
     networks:
       - app
+  redis:
+    image: "redis:alpine"
+    restart: always
+    container_name: redis
+    networks:
+      - app
   celery:
     image: ${PORTAL_TAG}
     container_name: celery

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,25 @@ services:
       driver: journald
     networks:
       - app
+  mariadb:
+    image: mariadb:${DB_TAG}
+    volumes:
+      - /var/lib/mysql:/var/lib/mysql
+    env_file:
+      - ./conf/portal/.chameleon_env
+    container_name: mariadb
+    restart: always
+    logging:
+      driver: journald
+    ports:
+      - "3306:3306"
+    networks:
+      - app
   nginx:
     image: nginx
     volumes:
       - /etc/letsencrypt/live/chameleoncloud.org/fullchain.pem:/etc/ssl/certs/portal.cer
       - /etc/letsencrypt/live/chameleoncloud.org/privkey.pem:/etc/ssl/private/portal.key
-      - /etc/letsencrypt/live/api.chameleoncloud.org/fullchain.pem:/etc/ssl/certs/api.portal.cer
-      - /etc/letsencrypt/live/api.chameleoncloud.org/privkey.pem:/etc/ssl/api.chameleoncloud.org.key
       - /etc/ssl/dhparams.pem:/etc/ssl/dhparam.pem
       - /var/www/chameleon/static:/static
       - /var/www/chameleon/media:/media
@@ -43,17 +55,13 @@ services:
       - nginx
     networks:
       - app
+    volumes:
+      - ./conf/referenceapi/reference-repository:/var/db/g5k-api/reference-repository/:ro
   memcached:
     image: memcached:latest
     command: ["-m", "512m"]
     container_name: memcached
     restart: always
-    networks:
-      - app
-  redis:
-    image: "redis:alpine"
-    restart: always
-    container_name: redis
     networks:
       - app
   celery:
@@ -64,8 +72,6 @@ services:
       - ./conf/portal/.chameleon_env
     logging:
       driver: journald
-    depends_on:
-      - redis
     networks:
       - app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,12 @@ services:
       - "3306:3306"
     networks:
       - app
+  redis:
+    image: "redis:alpine"
+    restart: always
+    container_name: redis
+    networks:
+      - app
   nginx:
     image: nginx
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,8 @@ services:
       - ./conf/portal/.chameleon_env
     logging:
       driver: journald
+    depends_on:
+      - redis
     networks:
       - app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - 80:80
       - 443:443
     container_name: nginx
+    hostname: chameleoncloud.org
     restart: always
     networks:
       - app


### PR DESCRIPTION
- Add DB_TAG to env
- Use new, merged Let's Encrypt certs for Reference API
- Update docker-compose for new portal hosts
- Misc fixes

These changes are already in use on the new portal hosts, but this is a formal request to merge them into camino