### PR TITLE
Added restart=always directive to celery docker-compose entry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       - redis
     networks:
       - app
+    restart: always
 
 networks:
   app:


### PR DESCRIPTION
This change comes after a portal outage where celery did not come back on and new approved user projects were not moved to the active state.